### PR TITLE
[reviving the PR today] Showcase release() for metrics #6

### DIFF
--- a/Sources/CoreMetrics/Metrics.swift
+++ b/Sources/CoreMetrics/Metrics.swift
@@ -1,4 +1,14 @@
-public protocol Counter: AnyObject {
+
+public protocol Metric: AnyObject {
+}
+
+// FIXME this would NOT be in the proposal, a library would identify its metrics however it wants.
+// This is needed to showcase how releasing generally works; NOT a full real implementation thereof and I'm not proposing adding this type.
+internal protocol NamedMetric: Metric {
+    var label: String { get }
+}
+
+public protocol Counter: Metric {
     func increment<DataType: BinaryInteger>(_ value: DataType)
 }
 
@@ -9,12 +19,12 @@ public extension Counter {
     }
 }
 
-public protocol Recorder: AnyObject {
+public protocol Recorder: Metric {
     func record<DataType: BinaryInteger>(_ value: DataType)
     func record<DataType: BinaryFloatingPoint>(_ value: DataType)
 }
 
-public protocol Timer: AnyObject {
+public protocol Timer: Metric {
     func recordNanoseconds(_ duration: Int64)
 }
 
@@ -54,6 +64,25 @@ public protocol MetricsHandler {
     func makeCounter(label: String, dimensions: [(String, String)]) -> Counter
     func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> Recorder
     func makeTimer(label: String, dimensions: [(String, String)]) -> Timer
+
+    /// Signal to the `MetricsHandler` that the passed in metric will no longer be updated.
+    /// The handler MAY release some resources associated with this metric in response to this information.
+    /// It is not required to act on this information immediately (or at all).
+    ///
+    /// Implementing `release` is optional, and one should refer to the underlying MetricsHandler for details (e.g. if releasing is a noop).
+    ///
+    /// Libraries instrumenting their own codebase with metrics should, as a best practice, call `release()` on metrics
+    /// whenever sure that a given `Metric` will never be updated again, for example when the library can determine that a given metric
+    /// will never be updated again (e.g. since the lifecycle of the resource the metric is concerned about has completed).
+    /// It is expected and normal that certain kinds of metrics do not experience such lifecycle bound and remain alive for
+    /// the entire lifetime of an application (e.g. global throughput metrics or similar).
+    func release<M: Metric>(metric: M)
+}
+public extension MetricsHandler {
+    func release<M: Metric>(metric: M) {
+        // intentionally left empty, some metrics systems have no need to implement releasing
+        // e.g. if they immediately send metrics off to another storage then they are stateless and don't need to "shut down"
+    }
 }
 
 public extension MetricsHandler {
@@ -109,7 +138,7 @@ public enum Metrics {
     public static func bootstrap(_ handler: MetricsHandler) {
         self.lock.withWriterLockVoid {
             // using a wrapper to avoid redundant and potentially expensive factory calls
-            self._handler = CachingMetricsHandler.wrap(handler)
+            self._handler = CachingMetricsHandler.wrap(handler) // TODO: I'd argue this is up to the handler implementation, some may not want this OR they can implement it better than a generic impl like we do here
         }
     }
 
@@ -166,11 +195,24 @@ private final class CachingMetricsHandler: MetricsHandler {
         return self.timers.getOrSet(label: label, dimensions: dimensions, maker: self.wrapped.makeTimer)
     }
 
+    func release<M: Metric>(metric: M) {
+        print("release \(metric)")
+        // in our caching implementation releasing means removing a metrics from the cache
+        // FIXME: just an example, I'd argue a metrics lib would have its own types and those would carry ID if they needed to release()
+        switch metric {
+        case let m as Counter & NamedMetric: self.counters.remove(label: m.label)
+        case let m as Recorder & NamedMetric: self.recorders.remove(label: m.label)
+        case let m as Timer & NamedMetric: self.timers.remove(label: m.label)
+        default: break // others, if they existed, are not cached
+        }
+    }
+
+
     private class Cache<T> {
         private var items = [String: T]()
         // using a mutex is never ideal, we will need to explore optimization options
         // once we see how real life workloads behaves
-        // for example, for short opetations like hashmap lookup mutexes are worst than r/w locks in 99% reads, but better than them in mixed r/w mode
+        // for example, for short operations like hashmap lookup mutexes are worst than r/w locks in 99% reads, but better than them in mixed r/w mode
         private let lock = Lock()
 
         func getOrSet(label: String, dimensions: [(String, String)], maker: (String, [(String, String)]) -> T) -> T {
@@ -183,6 +225,13 @@ private final class CachingMetricsHandler: MetricsHandler {
                     items[key] = item
                     return item
                 }
+            }
+        }
+
+        @discardableResult
+        func remove(label: String) -> Bool {
+            return self.lock.withLock {
+                return self.items.removeValue(forKey: label) != nil
             }
         }
 

--- a/Sources/Examples/CachingMetricsHandler.swift
+++ b/Sources/Examples/CachingMetricsHandler.swift
@@ -1,0 +1,162 @@
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+import Darwin
+#else
+import Glibc
+#endif
+
+@testable import CoreMetrics // because we need Locks
+import Foundation
+import protocol CoreMetrics.Timer // since otherwise conflicts with Foundation's
+
+/// Not serious example; in reality implementations would themselves rather decide if they need to cache metric values or not.
+// FIXME: proposing to remove this example, implementations should perform caching themselfes if they need to since they know their exact types.
+public final class CachingMetricsHandler: MetricsHandler {
+    private let wrapped: MetricsHandler
+    private var counters = Cache<LabelledCounter>()
+    private var recorders = Cache<LabelledRecorder>()
+    private var timers = Cache<LabelledTimer>()
+
+    public static func wrap(_ handler: MetricsHandler) -> CachingMetricsHandler {
+        if let caching = handler as? CachingMetricsHandler {
+            return caching
+        } else {
+            return CachingMetricsHandler(handler)
+        }
+    }
+
+    private init(_ wrapped: MetricsHandler) {
+        self.wrapped = wrapped
+    }
+
+    public func makeCounter(label: String, dimensions: [(String, String)]) -> Counter {
+        let make = { (label: String, dimensions: [(String, String)]) -> LabelledCounter in
+            let inner = self.wrapped.makeCounter(label: label, dimensions: dimensions)
+            return LabelledCounter(label: label, counter: inner)
+        }
+        return self.counters.getOrSet(label: label, dimensions: dimensions, maker: make)
+    }
+
+    public func makeRecorder(label: String, dimensions: [(String, String)], aggregate: Bool) -> Recorder {
+        let make  = { (label: String, dimensions: [(String, String)]) -> LabelledRecorder in
+            let recorder = self.wrapped.makeRecorder(label: label, dimensions: dimensions, aggregate: aggregate)
+            return LabelledRecorder(label: label, recorder: recorder)
+        }
+        return self.recorders.getOrSet(label: label, dimensions: dimensions, maker: make)
+    }
+
+    public func makeTimer(label: String, dimensions: [(String, String)]) -> Timer {
+        let make = { (label: String, dimensions: [(String, String)]) -> LabelledTimer in
+            let timer = self.wrapped.makeTimer(label: label, dimensions: dimensions)
+            return LabelledTimer(label: label, timer: timer)
+        }
+        return self.timers.getOrSet(label: label, dimensions: dimensions, maker: make)
+    }
+
+    public func release<M: Metric>(metric: M) {
+        print("release \(metric)")
+        // in our caching implementation releasing means removing a metrics from the cache
+        switch metric {
+        case let m as LabelledCounter: self.counters.remove(label: m.label)
+        case let m as LabelledRecorder : self.recorders.remove(label: m.label)
+        case let m as LabelledTimer: self.timers.remove(label: m.label)
+        default: break // others, if they existed, are not cached
+        }
+    }
+
+
+    private class Cache<T> {
+        private var items = [String: T]()
+        // using a mutex is never ideal, we will need to explore optimization options
+        // once we see how real life workloads behaves
+        // for example, for short operations like hashmap lookup mutexes are worst than r/w locks in 99% reads, but better than them in mixed r/w mode
+        private let lock = Lock()
+
+        func getOrSet(label: String, dimensions: [(String, String)], maker: (String, [(String, String)]) -> T) -> T {
+            let key = self.fqn(label: label, dimensions: dimensions)
+            return self.lock.withLock {
+                if let item = items[key] {
+                    return item
+                } else {
+                    // since we need to be able to handle unregister we wrap using the label
+                    // not the best way to deal with this, but we want to showcase how we could wrap/delegate
+                    let item = maker(label, dimensions)
+                    items[key] = item
+                    return item
+                }
+            }
+        }
+
+        @discardableResult
+        func remove(label: String) -> Bool {
+            return self.lock.withLock {
+                return self.items.removeValue(forKey: label) != nil
+            }
+        }
+
+        private func fqn(label: String, dimensions: [(String, String)]) -> String {
+            return [[label], dimensions.compactMap { "\($0.0).\($0.1)" }].flatMap { $0 }.joined(separator: ".")
+        }
+    }
+}
+
+
+/// An example of how a library may want to mark all of its `Metric` types in order to be able to suppose register/unregister-ing them.
+internal protocol LabelledMetric: Metric {
+    var label: String { get }
+}
+
+internal class LabelledCounter: LabelledMetric, Counter { // TODO: if we need wrappers then it would be useful to allow being a struct
+    let _label: String
+    let counter: Counter
+
+    init(label: String, counter: Counter) {
+        self._label = label
+        self.counter = counter
+    }
+
+    var label: String {
+        return self._label
+    }
+
+    func increment<DataType: BinaryInteger>(_ value: DataType) {
+        self.counter.increment(value)
+    }
+}
+internal class LabelledRecorder: LabelledMetric, Recorder {
+    let _label: String
+    let recorder: Recorder
+
+    init(label: String, recorder: Recorder) {
+        self._label = label
+        self.recorder = recorder
+    }
+
+    var label: String {
+        return self._label
+    }
+
+    func record<DataType: BinaryInteger>(_ value: DataType) {
+        self.recorder.record(value)
+    }
+
+    func record<DataType: BinaryFloatingPoint>(_ value: DataType) {
+        self.recorder.record(value)
+    }
+}
+internal class LabelledTimer: LabelledMetric, Timer {
+    let _label: String
+    let timer: Timer
+
+    init(label: String, timer: Timer) {
+        self._label = label
+        self.timer = timer
+    }
+
+    var label: String {
+        return self._label
+    }
+
+    func recordNanoseconds(_ duration: Int64) {
+        self.timer.recordNanoseconds(duration)
+    }
+}

--- a/Sources/Examples/ExampleMetricsLibrary.swift
+++ b/Sources/Examples/ExampleMetricsLibrary.swift
@@ -50,6 +50,25 @@ class ExampleMetricsLibrary: MetricsHandler {
         return item
     }
 
+    func release<M: Metric>(metric: M) {
+        switch metric {
+        case let counter as ExampleCounter:
+            guard let idx = counters.firstIndex(where: { $0.label == counter.label }) else { return }
+            counters.remove(at: idx)
+        case let recorder as ExampleRecorder:
+            guard let idx = recorders.firstIndex(where: { $0.label == recorder.label }) else { return }
+            recorders.remove(at: idx)
+        case let gauge as ExampleGauge:
+            guard let idx = recorders.firstIndex(where: { $0.label == gauge.label }) else { return }
+            gauges.remove(at: idx)
+        case let timer as ExampleTimer:
+            guard let idx = recorders.firstIndex(where: { $0.label == timer.label }) else { return }
+            timers.remove(at: idx)
+        default:
+            fatalError("Attempted to remove \(metric) which is not a supported metric type by \(ExampleMetricsLibrary.self)!")
+        }
+    }
+
     class Config {
         let recorder: RecorderConfig
         let timer: TimerConfig

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,8 @@
+import XCTest
+
+import MetricsTests
+
+var tests = [XCTestCaseEntry]()
+tests += MetricsTests.__allTests()
+
+XCTMain(tests)

--- a/Tests/MetricsTests/CoreMetricsTests.swift
+++ b/Tests/MetricsTests/CoreMetricsTests.swift
@@ -194,7 +194,7 @@ class MetricsTests: XCTestCase {
             counter.increment(value)
         }
         handlers.forEach { handler in
-            let counter = handler.counters[0] as! TestCounter
+            let counter = handler[counter: name] as! TestCounter
             XCTAssertEqual(counter.label, name, "expected label to match")
             XCTAssertEqual(counter.values.count, 1, "expected number of entries to match")
             XCTAssertEqual(counter.values[0].1, Int64(value), "expected value to match")
@@ -260,7 +260,8 @@ class MetricsTests: XCTestCase {
         XCTAssertNotEqual(counter5, counter, "expected caching to work with dimensions")
     }
 
-    func testLifecycle() throws {
+
+    func testReleasingMetrics() throws {
         // bootstrap with our test metrics
         let metrics = TestMetrics()
         Metrics.bootstrap(metrics)

--- a/Tests/MetricsTests/TestMetrics.swift
+++ b/Tests/MetricsTests/TestMetrics.swift
@@ -58,7 +58,7 @@ internal class TestCounter: Counter, Equatable {
     }
 }
 
-internal class TestRecorder: Recorder, Equatable {
+internal class TestRecorder: Recorder, Equatable, NamedMetric {
     let id: String
     let label: String
     let dimensions: [(String, String)]

--- a/Tests/MetricsTests/XCTestManifests.swift
+++ b/Tests/MetricsTests/XCTestManifests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+extension MetricsExtensionsTests {
+    static let __allTests = [
+        ("testTimerBlock", testTimerBlock),
+        ("testTimerWithDispatchTime", testTimerWithDispatchTime),
+        ("testTimerWithTimeInterval", testTimerWithTimeInterval),
+    ]
+}
+
+extension MetricsTests {
+    static let __allTests = [
+        ("testCaching", testCaching),
+        ("testCachingWithDimensions", testCachingWithDimensions),
+        ("testCounterBlock", testCounterBlock),
+        ("testCounters", testCounters),
+        ("testGauge", testGauge),
+        ("testGaugeBlock", testGaugeBlock),
+        ("testMUX", testMUX),
+        ("testRecorderBlock", testRecorderBlock),
+        ("testRecorders", testRecorders),
+        ("testRecordersFloat", testRecordersFloat),
+        ("testRecordersInt", testRecordersInt),
+        ("testReleasingMetrics", testReleasingMetrics),
+        ("testTimerBlock", testTimerBlock),
+        ("testTimers", testTimers),
+        ("testTimerVariants", testTimerVariants),
+    ]
+}
+
+#if !os(macOS)
+public func __allTests() -> [XCTestCaseEntry] {
+    return [
+        testCase(MetricsExtensionsTests.__allTests),
+        testCase(MetricsTests.__allTests),
+    ]
+}
+#endif


### PR DESCRIPTION
This PR illustrates the points of https://github.com/tomerd/swift-server-metrics-api-proposal/issues/6

If we agree we need such a thing then I'll remove the `NamedMetric` (since it would be IN an implementation, not the proposal) and most likely also `CachingMetricsHandler ` and leave in the new `release` method -- this way allowing implementations to do the right thing.