### PR TITLE
Add MetricsSystem.release() to allow metric lifetime management #6

### DIFF
--- a/Sources/Examples/ExampleMetricsLibrary.swift
+++ b/Sources/Examples/ExampleMetricsLibrary.swift
@@ -67,6 +67,40 @@ class ExampleMetricsLibrary: MetricsFactory {
         return item
     }
 
+
+    func release<M: MetricHandler>(metric: M) {
+        // we only release metrics that we ourselves created and keep in our caches:
+        switch metric {
+        case let counter as ExampleCounter:
+            lock.withLock {
+                if let idx = self.counters.firstIndex(where: { m in m.label == counter.label }) {
+                    self.counters.remove(at: idx)
+                }
+            }
+        case let gauge as ExampleGauge:
+            lock.withLock {
+                if let idx = self.gauges.firstIndex(where: { m in m.label == gauge.label }) {
+                    self.gauges.remove(at: idx)
+                }
+            }
+        case let recorder as ExampleRecorder:
+            lock.withLock {
+                if let idx = self.recorders.firstIndex(where: { m in m.label == recorder.label }) {
+                    self.recorders.remove(at: idx)
+                }
+            }
+        case let timer as ExampleTimer:
+            lock.withLock {
+                if let idx = self.timers.firstIndex(where: { m in m.label == timer.label }) {
+                    self.timers.remove(at: idx)
+                }
+            }
+        default:
+            // we can't release not "out" metrics; this could be considered a bug and fatal error here perhaps
+            return
+        }
+    }
+
     class Config {
         let recorder: RecorderConfig
         let timer: TimerConfig
@@ -99,12 +133,21 @@ class ExampleMetricsLibrary: MetricsFactory {
     }
 }
 
-class ExampleCounter: CounterHandler, CustomStringConvertible {
+/// In this `ExampleMetricsLibrary` we decided to have a shared type for our metrics as we will identify them by the label alone.
+/// Other libraries my implement identification differently; This example only goes to show how libraries can use manage identity (in the simplest case).
+class LabelledExampleHandler {
     let label: String
+
+    init(label: String) {
+        self.label = label
+    }
+}
+
+class ExampleCounter: LabelledExampleHandler, CounterHandler, CustomStringConvertible {
     let dimensions: [(String, String)]
     init(label: String, dimensions: [(String, String)]) {
-        self.label = label
         self.dimensions = dimensions
+        super.init(label: label)
     }
 
     let lock = NSLock()
@@ -120,14 +163,13 @@ class ExampleCounter: CounterHandler, CustomStringConvertible {
     }
 }
 
-class ExampleRecorder: RecorderHandler, CustomStringConvertible {
-    let label: String
+class ExampleRecorder: LabelledExampleHandler, RecorderHandler, CustomStringConvertible {
     let dimensions: [(String, String)]
     let options: [AggregationOption]
     init(label: String, dimensions: [(String, String)], options: [AggregationOption]) {
-        self.label = label
         self.dimensions = dimensions
         self.options = options
+        super.init(label: label)
     }
 
     private let lock = NSLock()
@@ -137,7 +179,7 @@ class ExampleRecorder: RecorderHandler, CustomStringConvertible {
     }
 
     func record<DataType: BinaryFloatingPoint>(_ value: DataType) {
-        // this may loose percision, but good enough as an example
+        // this may loose precision, but good enough as an example
         let v = Double(value)
         // TODO: sliding window
         lock.withLock {
@@ -226,12 +268,11 @@ class ExampleRecorder: RecorderHandler, CustomStringConvertible {
     }
 }
 
-class ExampleGauge: RecorderHandler, CustomStringConvertible {
-    let label: String
+class ExampleGauge: LabelledExampleHandler, RecorderHandler, CustomStringConvertible {
     let dimensions: [(String, String)]
     init(label: String, dimensions: [(String, String)]) {
-        self.label = label
         self.dimensions = dimensions
+        super.init(label: label)
     }
 
     let lock = NSLock()
@@ -241,7 +282,7 @@ class ExampleGauge: RecorderHandler, CustomStringConvertible {
     }
 
     func record<DataType: BinaryFloatingPoint>(_ value: DataType) {
-        // this may loose percision but good enough as an example
+        // this may loose precision but good enough as an example
         self.lock.withLock { _value = Double(value) }
     }
 

--- a/Sources/Examples/SimpleMetricsLibrary.swift
+++ b/Sources/Examples/SimpleMetricsLibrary.swift
@@ -55,7 +55,7 @@ class SimpleMetricsLibrary: MetricsFactory {
         }
 
         func record<DataType: BinaryFloatingPoint>(_ value: DataType) {
-            // this may loose percision, but good enough as an example
+            // this may loose precision, but good enough as an example
             let v = Double(value)
             // TODO: sliding window
             lock.withLock {
@@ -98,7 +98,7 @@ class SimpleMetricsLibrary: MetricsFactory {
         }
 
         func record<DataType: BinaryFloatingPoint>(_ value: DataType) {
-            // this may loose percision but good enough as an example
+            // this may loose precision but good enough as an example
             self.lock.withLock { _value = Double(value) }
         }
     }


### PR DESCRIPTION
Please see https://github.com/tomerd/swift-server-metrics-api-proposal/issues/6 for detailed rationale. In many metrics systems it is good to release metrics resources that are known to be no longer used.

For many metrics this may not matter if they are 'for the application' like "requests per second" etc since those never "go away", however in order to offer more fine grained metrics the number of metrics potentially stored in a metrics library "registry" may grow indefinitely potentially causing what could be seen as a leak. For this purpose a release() mechanism has to be in place in the shared API, in order to allow "middle ware" (any driver, web framework etc), to emit and release metrics whenever they see fit.

Since prometheus is mentioned in metrics discussions in SSWG quite a bit, please note that the release semantics do exist and are useful in Prometheus. So if we aim for that to be one of our backends, that by itself another reason to offer this API -- regardless of the heavy histograms case I point out in the README.

This can be discussed along the way as the API is proposed to become part of the SSWG projects I think @tomerd. Hope we'll nail it down quickly :-)

Resolves https://github.com/tomerd/swift-server-metrics-api-proposal/issues/6
Replaces #7 